### PR TITLE
Improve WriteVersionHeader

### DIFF
--- a/cmake/modules/WriteVersionHeader.cmake
+++ b/cmake/modules/WriteVersionHeader.cmake
@@ -61,13 +61,27 @@ function(WRITE_VERSION_HEADER _filename)
 	list(GET VERSION_LIST 1 WVH_MINOR)
 	list(GET VERSION_LIST 2 WVH_PATCH)
 
-	# Now dump the header:
-
-	file(WRITE "${_filename}"
+	# The content to write to disk:
+	set(CONTENT_TO_WRITE
 "#pragma once
 namespace ${WVH_NAME} {
+	namespace detail {
 	static int constexpr __version_var_major{${WVH_MAJOR}};
 	static int constexpr __version_var_minor{${WVH_MAJOR}};
 	static int constexpr __version_var_patch{${WVH_PATCH}};
-}")
+	} // namespace detail
+} // namespace ${WVH_NAME}
+")
+
+	# if we have a file already, check for changes first
+	if(EXISTS "${_filename}")
+		file(READ "${_filename}" ORIG_CONTENT)
+		if ("${ORIG_CONTENT}" STREQUAL "${CONTENT_TO_WRITE}")
+			# no need to write => timestamps stay unchanged
+			return()
+		endif()
+	endif()
+
+	# Now dump the content:
+	file(WRITE "${_filename}" "${CONTENT_TO_WRITE}")
 endfunction()

--- a/examples/ParameterMap_demo/main.cc
+++ b/examples/ParameterMap_demo/main.cc
@@ -17,8 +17,9 @@
 // along with krims. If not, see <http://www.gnu.org/licenses/>.
 //
 
-#include "krims/ParameterMap.hh"
 #include <iostream>
+#include <krims/ParameterMap.hh>
+#include <krims/version.hh>
 
 using namespace krims;
 
@@ -121,6 +122,10 @@ void modify_map_other(ParameterMap& map) {
 }
 
 int main() {
+  std::cout << "Using krims version " << krims::version::version_string()
+            << std::endl
+            << std::endl;
+
   ParameterMap map = make_map();
 
   std::cout << "Printing map" << std::endl;

--- a/src/krims/version.hh
+++ b/src/krims/version.hh
@@ -27,9 +27,9 @@ struct version {
   // Note: CMake automatically fills this version information
   // via the header version_defs.hh and the WriteVersionHeader module
 
-  static int constexpr major{__version_var_major};
-  static int constexpr minor{__version_var_minor};
-  static int constexpr patch{__version_var_patch};
+  static int constexpr major{detail::__version_var_major};
+  static int constexpr minor{detail::__version_var_minor};
+  static int constexpr patch{detail::__version_var_patch};
 
   // Return the version as a string
   static std::string version_string();


### PR DESCRIPTION
The variables __version_var_... are now put into the detail namespace
The header is only rewritten if the version has actually changed
(avoiding unnecessary recompiles)