### PR TITLE
Force clang-3.5 to compile code in C++11 mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ env:
 
 matrix:
   include:
-    # Clang 3.5 (has only c++11)
+    # Clang 3.5 with disabled c++14 support
     - install:
       # Repo for g++-4.9 (to avoid buggy libstdc++)
       - sudo add-apt-repository -y "ppa:ubuntu-toolchain-r/test"
@@ -47,7 +47,7 @@ matrix:
       - sudo apt-get update
       - sudo apt-get install -y ninja-build g++-4.9
       compiler: clang
-      env: CC_COMPILER="clang" CXX_COMPILER="clang++" TESTCASE="krims_tests_RELEASE"
+      env: CC_COMPILER="clang" CXX_COMPILER="clang++" TESTCASE="krims_tests_RELEASE" EXTRA_OPTS="-DDRB_HAS_CXX14_SUPPORT=OFF -DDRB_HIGHEST_CXX_SUPPORT=11"
     #
     # Clang 3.8 (has c++14)
     - install:


### PR DESCRIPTION
This ensures that the tests are run for C++11 code at least once in
Release mode.