### PR TITLE
Automatic resolution to file and linenr in backtraces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ script:
   - cmake -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_C_COMPILER=${CC_COMPILER}
            -DCMAKE_BUILD_TYPE=DebugRelease ${EXTRA_OPTS}
            -DRC_ENABLE_TESTS=OFF -DAUTOCHECKOUT_MISSING_REPOS=ON
+           -DKRIMS_ENABLE_EXPERIMENTAL=ON
            -GNinja ..
   - cmake --build  . -- -j ${CORES}
   - if [ "${TESTCASE}" ]; then ctest --output-on-failure -R ${TESTCASE}; else true; fi

--- a/cmake/setup_optional.cmake
+++ b/cmake/setup_optional.cmake
@@ -49,6 +49,15 @@ if (NOT CMAKE_CXX_STANDARD VERSION_LESS 17)
 	LIST(APPEND KRIMS_DEFINITIONS "KRIMS_HAVE_CXX17")
 endif()
 
+#############################
+#-- Experimental features --#
+#############################
+option(KRIMS_ENABLE_EXPERIMENTAL "Enable experimental features in krims" OFF)
+if(KRIMS_ENABLE_EXPERIMENTAL)
+	# Enable addr2line translation
+	message(STATUS "Enable experimental features for krims")
+	LIST(APPEND KRIMS_DEFINITIONS "KRIMS_ENABLE_EXPERIMENTAL")
+endif()
 
 ########################
 #-- Exception system --#

--- a/src/krims/CMakeLists.txt
+++ b/src/krims/CMakeLists.txt
@@ -24,8 +24,9 @@
 #
 set(KRIMS_SOURCES
 	version.cc
-	ExceptionSystem/exception_defs.cc
+	ExceptionSystem/backtrace.cc
 	ExceptionSystem/ExceptionBase.cc
+	ExceptionSystem/exception_defs.cc
 	ParameterMap.cc
 )
 

--- a/src/krims/ExceptionSystem/addr2line.hh
+++ b/src/krims/ExceptionSystem/addr2line.hh
@@ -1,0 +1,94 @@
+#pragma once
+
+#if defined KRIMS_USE_ADDR2LINE && defined DEBUG && \
+      defined KRIMS_HAVE_GLIBC_STACKTRACE
+// It only makes sense to define addr2line if we actually can make use of its
+// functionality, i.e. if we have a glibc stacktrace and are in DEBUG mode
+// (Debug symbols) and the user actually wants to use the feature
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+// Now we defined addr2line and it is available.
+#define KRIMS_ADDR2LINE_DEFINED
+
+namespace krims {
+
+/** Get the line of a file from the incoming address string
+ *
+ * \param execname   Path to the executable
+ * \param addr       Address string
+ * \param maxlen     The maximal length any of the strings may have
+ * \param codefile   The file name string which contains the address
+ * \param number     The line number in codefile which contains the address
+ *
+ * \returns -1 on any error, else 0
+ *
+ * This function is inspired by
+ * https://github.com/vmarkovtsev/DeathHandler/blob/master/death_handler.cc
+ */
+static int addr2line(const char* execname, const char* addr,
+                     const size_t maxlen, char* codefile, char* number) {
+  // By default set number and codefile to empty string
+  codefile[0] = 0;
+  number[0] = 0;
+
+  int pipefd[2];
+  if (pipe(pipefd) != 0) return -1;
+
+  pid_t pid = fork();
+  if (pid == -1) {
+    // Error forking
+    return -1;
+  } else if (pid == 0) {
+    // The child feeds on pipe[1]
+    // (from the process' stdout and stderr)
+    close(pipefd[0]);
+    dup2(pipefd[1], STDOUT_FILENO);
+    dup2(pipefd[1], STDERR_FILENO);
+
+    // Call addr2line
+    if (execlp("addr2line", "addr2line", addr, "-e", execname,
+               reinterpret_cast<void*>(NULL)) == -1) {
+      abort();
+    }
+  }
+
+  // Parent process receives on pipe[0]
+  close(pipefd[1]);
+
+  // Read data from the pipe
+  ssize_t len = read(pipefd[0], codefile, maxlen);
+  close(pipefd[0]);
+  if (len == 0) {
+    // eof encountered when reading from pipe
+    return -1;
+  }
+
+  // Put a null at the end
+  codefile[len] = 0;
+
+  // Wait for addr2line to be done
+  if (waitpid(pid, NULL, 0) != pid) {
+    // error wrong pid exited ... no way we can recover
+    abort();
+  }
+
+  // Split at ":"
+  char* colon = strstr(codefile, ":");
+  if (colon == NULL) {
+    // ":" not found, use everything for codefile.
+    return 0;
+  } else {
+    // colon points to the first occurrence of ":"
+    strcpy(number, colon + 1);
+    *colon = 0;
+    return 0;
+  }
+}
+
+}  // namespace krims
+#endif

--- a/src/krims/ExceptionSystem/backtrace.cc
+++ b/src/krims/ExceptionSystem/backtrace.cc
@@ -1,0 +1,90 @@
+//
+// Copyright (C) 2016 by the krims authors
+//
+// This file is part of krims.
+//
+// krims is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// krims is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with krims. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "backtrace.hh"
+#include <cstdlib>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace krims {
+
+#ifdef KRIMS_ADDR2LINE_AVAILABLE
+int addr2line(const char* execname, const char* addr, const size_t maxlen,
+              char* codefile, char* number) {
+  // By default set number and codefile to empty string
+  codefile[0] = 0;
+  number[0] = 0;
+
+  int pipefd[2];
+  if (pipe(pipefd) != 0) return -1;
+
+  pid_t pid = fork();
+  if (pid == -1) {
+    // Error forking
+    return -1;
+  } else if (pid == 0) {
+    // The child feeds on pipe[1]
+    // (from the process' stdout and stderr)
+    close(pipefd[0]);
+    dup2(pipefd[1], STDOUT_FILENO);
+    dup2(pipefd[1], STDERR_FILENO);
+
+    // Call addr2line
+    if (execlp("addr2line", "addr2line", addr, "-e", execname,
+               reinterpret_cast<void*>(NULL)) == -1) {
+      abort();
+    }
+  }
+
+  // Parent process receives on pipe[0]
+  close(pipefd[1]);
+
+  // Read data from the pipe
+  ssize_t len = read(pipefd[0], codefile, maxlen);
+  close(pipefd[0]);
+  if (len == 0) {
+    // eof encountered when reading from pipe
+    return -1;
+  }
+
+  // Put a null at the end
+  codefile[len] = 0;
+
+  // Wait for addr2line to be done
+  if (waitpid(pid, NULL, 0) != pid) {
+    // error wrong pid exited ... no way we can recover
+    abort();
+  }
+
+  // Split at ":"
+  char* colon = strstr(codefile, ":");
+  if (colon == NULL) {
+    // ":" not found, use everything for codefile.
+    return 0;
+  } else {
+    // colon points to the first occurrence of ":"
+    strcpy(number, colon + 1);
+    *colon = 0;
+    return 0;
+  }
+}
+#endif
+
+}  // namespace krims

--- a/src/krims/ExceptionSystem/backtrace.hh
+++ b/src/krims/ExceptionSystem/backtrace.hh
@@ -1,0 +1,57 @@
+//
+// Copyright (C) 2016 by the krims authors
+//
+// This file is part of krims.
+//
+// krims is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// krims is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with krims. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include <cstring>
+
+// TODO move all functionality which has to do with the backtrace here
+// also change it such that it operates on a pre-allocated piece of memory
+// only and only uses c-like functions. This way we can even invoke it
+// if we are catching a SIGSEV, see
+// https://github.com/vmarkovtsev/DeathHandler
+// for ideas.
+
+namespace krims {
+
+// TODO remove KRIMS_ENABLE_EXPERIMENTAL after some while
+#if defined DEBUG && defined KRIMS_HAVE_GLIBC_STACKTRACE && \
+      defined KRIMS_ENABLE_EXPERIMENTAL
+// It only makes sense to define addr2line if we actually can make use of its
+// functionality, i.e. if we have a glibc stacktrace and are in DEBUG mode
+// (Debug symbols)
+
+/** Get the line of a file from the incoming address string
+ *
+ * \param execname   Path to the executable
+ * \param addr       Address string
+ * \param maxlen     The maximal length any of the strings may have
+ * \param codefile   The file name string which contains the address
+ * \param number     The line number in codefile which contains the address
+ *
+ * \returns -1 on any error, else 0
+ *
+ * This function is inspired by
+ * https://github.com/vmarkovtsev/DeathHandler/blob/master/death_handler.cc
+ */
+int addr2line(const char* execname, const char* addr, const size_t maxlen,
+              char* codefile, char* number);
+#define KRIMS_ADDR2LINE_AVAILABLE
+
+#endif
+}  // namespace krims


### PR DESCRIPTION
Experimental feature; only enabled if compiled with
KRIMS_ENABLE_EXPERIMENTAL set to ON.