### PR TITLE
Reorganised NumComp code

### DIFF
--- a/src/krims/CMakeLists.txt
+++ b/src/krims/CMakeLists.txt
@@ -28,6 +28,7 @@ set(KRIMS_SOURCES
 	ExceptionSystem/ExceptionBase.cc
 	ExceptionSystem/exception_defs.cc
 	ParameterMap.cc
+	NumComp/NumCompConstants.cc
 )
 
 # Dump the current version as an include file.

--- a/src/krims/NumComp/NumComp.hh
+++ b/src/krims/NumComp/NumComp.hh
@@ -1,0 +1,131 @@
+//
+// Copyright (C) 2016 by the krims authors
+//
+// This file is part of krims.
+//
+// krims is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// krims is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with krims. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include "NumCompConstants.hh"
+#include "NumEqual.hh"
+#include <limits>
+#include <type_traits>
+
+namespace krims {
+
+/** Struct to provide functions which check allow for numeric-aware comparison
+ * between objects */
+template <typename T>
+class NumComp {
+public:
+  // TODO hard-coded double type
+  typedef typename std::conditional<std::is_floating_point<T>::value, T,
+                                    double>::type error_type;
+
+  /** Construct an NumComp object */
+  explicit NumComp(const T& value)
+        : m_tolerance(0),
+          m_failure_action(NumCompConstants::default_failure_action),
+          m_value(value) {
+    tolerance(NumCompAccuracyLevel::Default);
+  }
+
+  /** Modify the tolerance by providing a different accuracy level */
+  NumComp& tolerance(const NumCompAccuracyLevel accuracy);
+
+  /** Modify the comparison tolerance */
+  NumComp& tolerance(const error_type tolerance) {
+    m_tolerance = tolerance;
+    return *this;
+  }
+
+  NumComp& failure_action(const NumCompActionType failure_action) {
+    m_failure_action = failure_action;
+    return *this;
+  }
+
+  //@{
+  /** Compare with another object for equality */
+  template <typename U>
+  friend bool operator==(const U& lhs, const NumComp& rhs) {
+    return NumEqual<U, T>{rhs.m_tolerance, rhs.m_failure_action}(lhs,
+                                                                 rhs.m_value);
+  }
+
+  template <typename U>
+  friend bool operator==(const NumComp& lhs, const U& rhs) {
+    return rhs == lhs;
+  }
+  //@}
+
+private:
+  /** \brief tolerance when comparing objects */
+  error_type m_tolerance;
+
+  //! The action to perform if a comparison fails
+  NumCompActionType m_failure_action;
+
+  /** The value  */
+  const T& m_value;
+};
+
+/** Helper function to make an NumComp<T> object */
+template <typename T>
+NumComp<T> numcomp(const T& value) {
+  return NumComp<T>(value);
+}
+
+//
+// ----------------------------------------------------------------------------
+//
+
+template <typename T>
+NumComp<T>& NumComp<T>::tolerance(const NumCompAccuracyLevel accuracy) {
+  error_type factor = NumCompConstants::default_tolerance_factor;
+
+  switch (accuracy) {
+    case NumCompAccuracyLevel::MachinePrecision:
+      factor = 1.;
+      break;
+    case NumCompAccuracyLevel::TenMachinePrecision:
+      factor = 10.;
+      break;
+    case NumCompAccuracyLevel::Extreme:
+      factor /= 100.;
+      break;
+    case NumCompAccuracyLevel::Higher:
+      factor /= 10.;
+      break;
+    case NumCompAccuracyLevel::Default:
+      break;
+    case NumCompAccuracyLevel::Lower:
+      factor *= 10.;
+      break;
+    case NumCompAccuracyLevel::Sloppy:
+      factor *= 100.;
+      break;
+    case NumCompAccuracyLevel::SuperSloppy:
+      factor *= 1000.;
+      break;
+  }
+
+  // Make sure factor is at least one:
+  if (factor < 1.) factor = 1.;
+
+  m_tolerance = factor * std::numeric_limits<error_type>::epsilon();
+  return *this;
+}
+
+}  // namespace krims

--- a/src/krims/NumComp/NumCompConstants.cc
+++ b/src/krims/NumComp/NumCompConstants.cc
@@ -17,8 +17,11 @@
 // along with krims. If not, see <http://www.gnu.org/licenses/>.
 //
 
-#pragma once
-#include "NumComp/NumComp.hh"
-#include "NumComp/NumCompConstants.hh"
-#include "NumComp/NumCompConstantsChangeSafe.hh"
-#include "NumComp/NumCompException.hh"
+#include "NumCompConstants.hh"
+
+namespace krims {
+double NumCompConstants::default_tolerance_factor = 100.;
+NumCompActionType NumCompConstants::default_failure_action =
+      NumCompActionType::Return;
+
+}  // namespace krims

--- a/src/krims/NumComp/NumCompConstants.hh
+++ b/src/krims/NumComp/NumCompConstants.hh
@@ -1,0 +1,84 @@
+//
+// Copyright (C) 2016 by the krims authors
+//
+// This file is part of krims.
+//
+// krims is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// krims is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with krims. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+
+namespace krims {
+
+/** What action to undertake in case a comparison fails:
+ * Return false, throw an NumCompException or throw a verbose
+ * NumCompException */
+enum class NumCompActionType { Return, ThrowNormal, ThrowVerbose };
+
+/** A flag to increase or decrease the tolerance based on the default
+ *  value in order to change the accuracy for which the numerical
+ *  comparison checks.
+ *
+ * MachinePrecision => std::numeric_limits<error_type>::epsilon()
+ * TenMachinePrecision => 10*std::numeric_limits<error_type>::epsilon()
+ * Extreme     => tolerance_factor /  100 * MachinePrecision
+ * Higher      => tolerance_factor /   10 * MachinePrecision
+ * Default     => tolerance_factor        * MachinePrecision
+ * Lower       => tolerance_factor *   10 * MachinePrecision
+ * Sloppy      => tolerance_factor *  100 * MachinePrecision
+ * SuperSloppy => tolerance_factor * 1000 * MachinePrecision
+ *
+ * where tolerance_factor is NumCompConstants::default_tolerance_factor
+ **/
+enum class NumCompAccuracyLevel {
+  /** equals std::numeric_limits<error_type>::epsilon() */
+  MachinePrecision,
+
+  /** equals 10*std::numeric_limits<error_type>::epsilon() */
+  TenMachinePrecision,
+
+  /** equals tolerance_factor /  100 * MachinePrecision */
+  Extreme,
+
+  /** equals tolerance_factor /   10 * MachinePrecision */
+  Higher,
+
+  /** equals tolerance_factor        * MachinePrecision */
+  Default,
+
+  /** equals tolerance_factor *   10 * MachinePrecision */
+  Lower,
+
+  /** equals tolerance_factor *  100 * MachinePrecision */
+  Sloppy,
+
+  /** equals tolerance_factor * 1000 * MachinePrecision */
+  SuperSloppy,
+};
+
+/** A struct which holds static constants influencing the default behaviour of
+ * NumComp */
+struct NumCompConstants {
+  /** The default tolerance_factor to use
+   *
+   * \see NumCompAccuracyLevel for more details.
+   * */
+  static double default_tolerance_factor;
+  // TODO hard-coded double type
+
+  /** The default failure action */
+  static NumCompActionType default_failure_action;
+};
+
+}  // namespace krims

--- a/src/krims/NumComp/NumCompConstantsChangeSafe.hh
+++ b/src/krims/NumComp/NumCompConstantsChangeSafe.hh
@@ -1,0 +1,75 @@
+//
+// Copyright (C) 2016 by the krims authors
+//
+// This file is part of krims.
+//
+// krims is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// krims is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with krims. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include "NumCompConstants.hh"
+namespace krims {
+
+/** A struct to temporarily change the NumCompConstants.
+ *  Once the class goes out of scope and is destroyed, the original
+ *  settings are restored */
+class NumCompConstantsChangeSafe {
+private:
+  NumCompConstantsChangeSafe()
+        : m_orig_default_tolerance_factor(
+                NumCompConstants::default_tolerance_factor),
+          m_orig_default_failure_action(
+                NumCompConstants::default_failure_action) {}
+
+public:
+  /** Change the tolerance factor until the class goes out of scope */
+  NumCompConstantsChangeSafe(double tolerance_factor)
+        : NumCompConstantsChangeSafe{} {
+    NumCompConstants::default_tolerance_factor = tolerance_factor;
+  }
+
+  /** Change the default failure action until the class goes out of scope */
+  NumCompConstantsChangeSafe(NumCompActionType failure_action)
+        : NumCompConstantsChangeSafe{} {
+    NumCompConstants::default_failure_action = failure_action;
+  }
+
+  /** Change both the default failure action as well as the tolerance factor
+   * until the class goes out of scope*/
+  NumCompConstantsChangeSafe(double tolerance_factor,
+                             NumCompActionType failure_action)
+        : NumCompConstantsChangeSafe{} {
+    NumCompConstants::default_tolerance_factor = tolerance_factor;
+    NumCompConstants::default_failure_action = failure_action;
+  }
+
+  ~NumCompConstantsChangeSafe() {
+    NumCompConstants::default_failure_action = m_orig_default_failure_action;
+    NumCompConstants::default_tolerance_factor =
+          m_orig_default_tolerance_factor;
+  }
+
+  // Disallow moving or copying the class around:
+  NumCompConstantsChangeSafe(const NumCompConstantsChangeSafe&) = delete;
+  NumCompConstantsChangeSafe(NumCompConstantsChangeSafe&&) = delete;
+  NumCompConstantsChangeSafe& operator=(NumCompConstantsChangeSafe&&) = delete;
+  NumCompConstantsChangeSafe& operator=(const NumCompConstantsChangeSafe&) =
+        delete;
+
+private:
+  double m_orig_default_tolerance_factor;
+  NumCompActionType m_orig_default_failure_action;
+};
+
+}  // namespace krims

--- a/src/krims/NumComp/NumCompException.hh
+++ b/src/krims/NumComp/NumCompException.hh
@@ -1,0 +1,107 @@
+//
+// Copyright (C) 2016 by the krims authors
+//
+// This file is part of krims.
+//
+// krims is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// krims is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with krims. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include "krims/ExceptionSystem.hh"
+#include <iomanip>
+
+namespace krims {
+
+/** Exception raised by the NumComp operations if they fail on some objects. */
+template <typename T>
+class NumCompException : public ExceptionBase {
+public:
+  static_assert(std::is_arithmetic<T>::value,
+                "T needs to be an arithmetic value");
+  // otherwise the declaration of T as error and tolerance makes no sense.
+
+  NumCompException(const T lhs_, const T rhs_, const T error_,
+                   const T tolerance_, const std::string operation_string_,
+                   std::string description_ = "") noexcept
+        : lhs(lhs_),
+          rhs(rhs_),
+          error(error_),
+          tolerance(tolerance_),
+          operation_string(operation_string_),
+          description(description_) {}
+
+  //! The value of the lhs
+  const T lhs;
+
+  //! The value of the rhs
+  const T rhs;
+
+  //! The error that was obtained
+  const T error;
+
+  //! The tolerance we applied
+  const T tolerance;
+
+  //! A string describing the operation (like "==" or "!=")
+  const std::string operation_string;
+
+  //! The description that was additionally supplied
+  std::string description;
+
+  //! Append some extra data to the description:
+  void append(const std::string& extra);
+
+  /** Add enhancing exception data */
+  void add_exc_data(const char* file, int line, const char* function);
+
+  /** Print exception-specific extra information to the outstream */
+  virtual void print_extra(std::ostream& out) const noexcept;
+
+private:
+  std::string failed_condition{""};
+};
+
+//
+// --------------------------------------------------------------
+//
+
+template <typename T>
+void NumCompException<T>::append(const std::string& extra) {
+  if (description != "") {
+    description += " ";
+  }
+  description += extra;
+}
+
+template <typename T>
+void NumCompException<T>::add_exc_data(const char* file, int line,
+                                       const char* function) {
+  std::stringstream ss;
+  ss << std::scientific << std::setprecision(15) << lhs << operation_string
+     << rhs << " (tol: " << tolerance << ")";
+  failed_condition = ss.str();
+  ExceptionBase::add_exc_data(file, line, function, failed_condition.c_str(),
+                              "NumCompException");
+}
+
+template <typename T>
+void NumCompException<T>::print_extra(std::ostream& out) const noexcept {
+  out << std::scientific << std::setprecision(15) << "Error in comparison ("
+      << error << ") larger than tolerance (" << tolerance << ").";
+  if (description != "") {
+    out << std::endl << description;
+  }
+}
+
+}  // namespace krims

--- a/src/krims/NumComp/NumEqual.hh
+++ b/src/krims/NumComp/NumEqual.hh
@@ -1,0 +1,160 @@
+//
+// Copyright (C) 2016 by the krims authors
+//
+// This file is part of krims.
+//
+// krims is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// krims is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with krims. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#pragma once
+#include "NumCompConstants.hh"
+#include "NumCompException.hh"
+#include <cmath>
+#include <complex>
+
+namespace krims {
+
+/** \brief Functor to check that two values are numerically equal --- generic
+ * case (which is an empty class)*/
+template <typename T, typename U, typename Enable = void>
+struct NumEqual {};  // no implementation of operator()
+
+/** \brief Functor to check that two floating point values are numerically equal
+ */
+template <typename T, typename U>
+struct NumEqual<
+      T, U, typename std::enable_if<std::is_floating_point<T>::value &&
+                                    std::is_floating_point<U>::value>::type> {
+  typedef const T& first_argument_type;
+  typedef const U& second_argument_type;
+  typedef bool result_type;
+
+  typedef typename std::common_type<T, U>::type common_type;
+
+  NumEqual(const common_type tolerance, const NumCompActionType failure_action)
+        : m_tolerance(tolerance), m_failure_action(failure_action) {}
+
+  bool operator()(const T& lhs, const U& rhs) const;
+
+private:
+  const common_type m_tolerance;
+  const NumCompActionType m_failure_action;
+};
+
+/** \brief Functor to check that two complex numbers are numerically equal
+ */
+template <typename T, typename U>
+struct NumEqual<
+      std::complex<T>, std::complex<U>,
+      typename std::enable_if<std::is_floating_point<T>::value &&
+                              std::is_floating_point<U>::value>::type> {
+  typedef const std::complex<T>& first_argument_type;
+  typedef const std::complex<U>& second_argument_type;
+  typedef bool result_type;
+
+  typedef typename std::common_type<T, U>::type common_real_type;
+
+  NumEqual(const common_real_type tolerance,
+           const NumCompActionType failure_action)
+        : m_tolerance(tolerance), m_failure_action(failure_action) {}
+
+  bool operator()(const std::complex<T>& lhs, const std::complex<U>& rhs) const;
+
+private:
+  const common_real_type m_tolerance;
+  const NumCompActionType m_failure_action;
+};
+
+//
+
+//
+
+template <typename T, typename U>
+bool NumEqual<T, U,
+              typename std::enable_if<std::is_floating_point<T>::value &&
+                                      std::is_floating_point<U>::value>::type>::
+operator()(const T& lhs, const U& rhs) const {
+  using std::abs;
+
+  // This comparison algorithm is based on these resources:
+  //    http://realtimecollisiondetection.net/blog/?p=89
+  //    https://stackoverflow.com/questions/17333/most-effective-way-for-float-and-double-comparison
+
+  if (lhs == rhs) {
+    // shortcut, which handles infinities
+    return true;
+  } else {
+    // This essentially does absolute comparision if lhs and rhs are small
+    // compared to the tolerance else it does relative comparsion
+
+    const common_type absdiff = abs(lhs - rhs);
+    const common_type maxone = std::max({static_cast<common_type>(1),
+                                         static_cast<common_type>(abs(lhs)),
+                                         static_cast<common_type>(abs(rhs))});
+    const bool equal = absdiff <= m_tolerance * maxone;
+
+    // Alternative to control tolerance for absolute comparison (absErr)
+    // and relative comparison (relErr) separately:
+    // bool equal = absdiff <= max(absErr, relErr * max(abs(lhs),abs(rhs)))
+
+    if (equal) {
+      return true;
+    } else if (m_failure_action == NumCompActionType::ThrowNormal ||
+               m_failure_action == NumCompActionType::ThrowVerbose) {
+      const common_type error = absdiff / maxone;
+      NumCompException<common_type> e(lhs, rhs, error, m_tolerance, "==");
+      e.add_exc_data(__FILE__, __LINE__, __PRETTY_FUNCTION__);
+      throw e;
+    } else {
+      return false;
+    }
+  }
+}
+
+template <typename T, typename U>
+bool NumEqual<std::complex<T>, std::complex<U>,
+              typename std::enable_if<std::is_floating_point<T>::value &&
+                                      std::is_floating_point<U>::value>::type>::
+operator()(const std::complex<T>& lhs, const std::complex<U>& rhs) const {
+  NumEqual<T, U> is_equal{m_tolerance, m_failure_action};
+
+  std::string part;
+  try {
+    // First compare real.
+    // If failure action is throw and the comparison fails
+    // we get to the catch part below and use the part string
+    // to identify which part has failed.
+    part = "Real part";
+    const bool real_equal = is_equal(lhs.real(), rhs.real());
+
+    // Now compare imaginary
+    // If we get through both we return the combined result.
+    part = "Imaginary part";
+    return real_equal && is_equal(lhs.imag(), rhs.imag());
+  } catch (NumCompException<common_real_type>& e) {
+    // If we get here failure_action is some kind of Throw
+    // So we rethrow what we caught.
+    std::stringstream ss;
+
+    ss << part;
+    if (m_failure_action == NumCompActionType::ThrowVerbose) {
+      ss << " of complex numbers " << lhs << " and " << rhs;
+    }
+    ss << " is not equal.";
+    e.append(ss.str());
+    throw;
+  }
+}
+
+}  // namespace krims


### PR DESCRIPTION
Various smaller BugFixes and improvements:
- Both sides of the == may now take different types
- Constants are a header and a source file
- NumCompChangeSafe class to safely change the global NumCompConstants
  (such that they are changed back appropriately once this class goes
  out of scope)