### PR TITLE
Add NumCompExceptionBase as type-independent Base

### DIFF
--- a/src/krims/CMakeLists.txt
+++ b/src/krims/CMakeLists.txt
@@ -29,6 +29,7 @@ set(KRIMS_SOURCES
 	ExceptionSystem/ExceptionBase.cc
 	ExceptionSystem/exception_defs.cc
 	ParameterMap.cc
+	NumComp/NumCompException.cc
 	NumComp/NumCompConstants.cc
 )
 

--- a/src/krims/NumComp/NumCompException.cc
+++ b/src/krims/NumComp/NumCompException.cc
@@ -1,0 +1,31 @@
+//
+// Copyright (C) 2016 by the krims authors
+//
+// This file is part of krims.
+//
+// krims is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// krims is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with krims. If not, see <http://www.gnu.org/licenses/>.
+//
+
+#include "NumCompException.hh"
+
+namespace krims {
+
+void NumCompExceptionBase::append(const std::string& extra) {
+  if (description != "") {
+    description += " ";
+  }
+  description += extra;
+}
+
+}  // namespace krims

--- a/src/krims/NumComp/NumCompException.hh
+++ b/src/krims/NumComp/NumCompException.hh
@@ -23,9 +23,23 @@
 
 namespace krims {
 
+/** Base exception of all NumCompExceptions. Catch these to get all NumComp
+ *  Exceptions type-indepentantly */
+class NumCompExceptionBase : public ExceptionBase {
+public:
+  NumCompExceptionBase(std::string description_) noexcept
+        : description(description_) {}
+
+  //! The description that was additionally supplied
+  std::string description;
+
+  //! Append some extra data to the description:
+  void append(const std::string& extra);
+};
+
 /** Exception raised by the NumComp operations if they fail on some objects. */
 template <typename T>
-class NumCompException : public ExceptionBase {
+class NumCompException : public NumCompExceptionBase {
 public:
   static_assert(std::is_arithmetic<T>::value,
                 "T needs to be an arithmetic value");
@@ -33,13 +47,13 @@ public:
 
   NumCompException(const T lhs_, const T rhs_, const T error_,
                    const T tolerance_, const std::string operation_string_,
-                   std::string description_ = "") noexcept
-        : lhs(lhs_),
+                   const std::string description_ = "") noexcept
+        : NumCompExceptionBase{description_},
+          lhs(lhs_),
           rhs(rhs_),
           error(error_),
           tolerance(tolerance_),
-          operation_string(operation_string_),
-          description(description_) {}
+          operation_string(operation_string_) {}
 
   //! The value of the lhs
   const T lhs;
@@ -56,12 +70,6 @@ public:
   //! A string describing the operation (like "==" or "!=")
   const std::string operation_string;
 
-  //! The description that was additionally supplied
-  std::string description;
-
-  //! Append some extra data to the description:
-  void append(const std::string& extra);
-
   /** Add enhancing exception data */
   void add_exc_data(const char* file, int line, const char* function);
 
@@ -75,14 +83,6 @@ private:
 //
 // --------------------------------------------------------------
 //
-
-template <typename T>
-void NumCompException<T>::append(const std::string& extra) {
-  if (description != "") {
-    description += " ";
-  }
-  description += extra;
-}
 
 template <typename T>
 void NumCompException<T>::add_exc_data(const char* file, int line,
@@ -99,8 +99,8 @@ template <typename T>
 void NumCompException<T>::print_extra(std::ostream& out) const noexcept {
   out << std::scientific << std::setprecision(15) << "Error in comparison ("
       << error << ") larger than tolerance (" << tolerance << ").";
-  if (description != "") {
-    out << std::endl << description;
+  if (NumCompExceptionBase::description != "") {
+    out << std::endl << NumCompExceptionBase::description;
   }
 }
 

--- a/src/krims/NumComp/NumEqual.hh
+++ b/src/krims/NumComp/NumEqual.hh
@@ -28,7 +28,11 @@ namespace krims {
 /** \brief Functor to check that two values are numerically equal --- generic
  * case (which is an empty class)*/
 template <typename T, typename U, typename Enable = void>
-struct NumEqual {};  // no implementation of operator()
+struct NumEqual {
+  static_assert(!std::is_same<Enable, void>::value,
+                "NumEqual has not been specialised for these types.");
+  // no implementation of operator()
+};
 
 /** \brief Functor to check that two floating point values are numerically equal
  */
@@ -99,9 +103,8 @@ operator()(const T& lhs, const U& rhs) const {
     // compared to the tolerance else it does relative comparsion
 
     const common_type absdiff = abs(lhs - rhs);
-    const common_type maxone = std::max({static_cast<common_type>(1),
-                                         static_cast<common_type>(abs(lhs)),
-                                         static_cast<common_type>(abs(rhs))});
+    const common_type maxside = std::max<common_type>(abs(lhs), abs(rhs));
+    const common_type maxone = std::max<common_type>(1, maxside);
     const bool equal = absdiff <= m_tolerance * maxone;
 
     // Alternative to control tolerance for absolute comparison (absErr)
@@ -142,7 +145,7 @@ operator()(const std::complex<T>& lhs, const std::complex<U>& rhs) const {
     // If we get through both we return the combined result.
     part = "Imaginary part";
     return real_equal && is_equal(lhs.imag(), rhs.imag());
-  } catch (NumCompException<common_real_type>& e) {
+  } catch (NumCompExceptionBase& e) {
     // If we get here failure_action is some kind of Throw
     // So we rethrow what we caught.
     std::stringstream ss;

--- a/tests/NumCompTests.cc
+++ b/tests/NumCompTests.cc
@@ -121,8 +121,7 @@ TEST_CASE("NumComp tests", "[NumComp]") {
 
     // Note: The cast to void is to "fake-use" the comparsion result, which is
     // not of interest in this case
-    REQUIRE_THROWS_AS((void)(10.000 == numcomp(10.001)),
-                      NumCompException<double>);
+    REQUIRE_THROWS_AS((void)(10.000 == numcomp(10.001)), NumCompExceptionBase);
 
     try {
       (void)(10.000 ==
@@ -164,6 +163,11 @@ TEST_CASE("NumComp tests", "[NumComp]") {
             1e4 * std::numeric_limits<double>::epsilon());
       CHECK(e.error == Approx(0.0000001));
     }
+
+    REQUIRE_THROWS_AS(
+          (void)(0. ==
+                 numcomp(0.0000001).tolerance(NumCompAccuracyLevel::Extreme)),
+          NumCompExceptionBase);
 
     REQUIRE(100.000000 == numcomp(100.000001).tolerance(1e-8));
     REQUIRE(10.0 == numcomp(10.01).tolerance(1e-3));


### PR DESCRIPTION
All NumCompExceptions now derive from NumCompExceptionBase irrespective
of the scalar type they have. This makes catching them and dealing with
them easier.