### PR TITLE
Re-introduce NumCompExceptionBase

### DIFF
--- a/src/krims/NumComp/NumCompException.hh
+++ b/src/krims/NumComp/NumCompException.hh
@@ -24,9 +24,11 @@
 
 namespace krims {
 
+class NumCompExceptionBase : public ExceptionBase {};
+
 /** Exception raised by the NumComp operations if they fail on some objects. */
 template <typename T>
-class NumCompException : public ExceptionBase {
+class NumCompException : public NumCompExceptionBase {
  public:
   static_assert(std::is_arithmetic<T>::value, "T needs to be an arithmetic value");
   // otherwise the declaration of T as error and tolerance makes no sense.

--- a/src/krims/NumComp/NumEqual.hh
+++ b/src/krims/NumComp/NumEqual.hh
@@ -141,7 +141,7 @@ operator()(const std::complex<T>& lhs, const std::complex<U>& rhs) const {
     // If we get through both we return the combined result.
     part = "Imaginary part";
     return real_equal && is_equal(lhs.imag(), rhs.imag());
-  } catch (ExceptionBase& e) {
+  } catch (NumCompExceptionBase& e) {
     // If we get here failure_action is some kind of Throw
     // So we rethrow what we caught.
     std::stringstream ss;


### PR DESCRIPTION
This makes it easier to catch numerical comparison exceptions, because a common base exists.