### PR TITLE
Bugfixes and small extensions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,8 @@ matrix:
       - export TESTS=0
       compiler: clang
       env: CC_COMP="clang-3.9" CXX_COMP="clang++-3.9"
+  allow_failures:
+    - env: CC_COMP="clang-3.9" CXX_COMP="clang++-3.9" BUILD_TARGET="clang-tidy-krims"
 
 script:
   - cmake --version

--- a/cmake/modules/SetupClangTargets.cmake
+++ b/cmake/modules/SetupClangTargets.cmake
@@ -468,7 +468,7 @@ is not used to compile the project.")
 		COMMAND
 		${CMAKE_COMMAND} -E make_directory ${FIXDIR}
 		COMMAND
-		${CMAKE_COMMANaD} -E remove -f ${APPLYFILE}
+		${CMAKE_COMMAND} -E remove -f ${APPLYFILE}
 		COMMAND
 		${YAML_MERGER} -o "${FIXFILE}" ${SOURCE_FIX_FILES}
 		COMMAND

--- a/cmake/setup_dependencies.cmake
+++ b/cmake/setup_dependencies.cmake
@@ -21,14 +21,14 @@
 
 # sets these things
 #
-#       KRIMS_DEPENDENCIES			everyone needs these libraries
-#       KRIMS_DEPENDENCIES_DEBUG		debug mode needs these extras
-#       KRIMS_DEPENDENCIES_RELEASE		release mode needs these extras
-#       KRIMS_DEPENDENCIES_TEST		tests need these extra libraries
+#       KRIMS_DEPENDENCIES                 everyone needs these libraries
+#       KRIMS_DEPENDENCIES_DEBUG           debug mode needs these extras
+#       KRIMS_DEPENDENCIES_RELEASE         release mode needs these extras
+#       KRIMS_DEPENDENCIES_TEST            tests need these extra libraries
 #
-#       KRIMS_DEFINITIONS			definitions for all compilation
-#       KRIMS_DEFINITIONS_DEBUG		definitions for debug mode
-#       KRIMS_DEFINITIONS_RELEASE		definitions for release mode
+#       KRIMS_DEFINITIONS                  definitions for all compilation
+#       KRIMS_DEFINITIONS_DEBUG            definitions for debug mode
+#       KRIMS_DEFINITIONS_RELEASE          definitions for release mode
 #
 
 ####################

--- a/src/krims/ExceptionSystem/ExceptionBase.hh
+++ b/src/krims/ExceptionSystem/ExceptionBase.hh
@@ -38,7 +38,7 @@ class ExceptionBase : public std::exception {
           m_line(0),
           m_function("?"),
           m_failed_condition("?"),
-          m_extra("(none"),
+          m_extra("(none)"),
           m_what_str{"Failed to generate the exception message."} {}
 
   /** Default copy constructor */

--- a/src/krims/Range.hh
+++ b/src/krims/Range.hh
@@ -59,19 +59,27 @@ class Range {
 
   /** \brief Construct a range
    *
-   * Note that the interval is half-open, i.e. the range
+   * Construct the range [first, last). If last is smaller or equal
+   * to first, the range is empty.
+   *
+   * \note The interval is half-open, i.e. the range
    * is including the first element but not the last.
    * */
-  Range(value_type first, value_type last) : m_first(first), m_last(last) {
+  Range(value_type first, value_type last)
+        : m_first(first), m_last(std::max(first, last)) {
     assert_greater_equal(m_first, m_last);
   }
   /** \brief Construct from pair
    *
-   * The first element is inclusive, the last exclusive
-   * (half-open interval)
+   * Construct the range [first, second). If second is smaller or equal
+   * to first, the range is empty.
+   *
+   * \note The interval is half-open, i.e. first is inclusive, but second
+   * exclusive.
    */
   explicit Range(std::pair<value_type, value_type> first_last)
-        : m_first(first_last.first), m_last(first_last.second) {
+        : m_first(first_last.first),
+          m_last(std::max(first_last.first, first_last.second)) {
     assert_greater_equal(m_first, m_last);
   }
 
@@ -80,7 +88,8 @@ class Range {
    * i.e. if this class represents [3,5) it returns 2.
    * */
   size_type length() const {
-    return static_cast<diff_type>(m_last) - static_cast<diff_type>(m_first);
+    return static_cast<size_type>(static_cast<diff_type>(m_last) -
+                                  static_cast<diff_type>(m_first));
   }
 
   /** \brief Return the effective number of elements in the range

--- a/tests/RangeTests.cc
+++ b/tests/RangeTests.cc
@@ -41,9 +41,8 @@ struct RangeTests {
       RC_ASSERT(r.lower_bound() == t1);
       RC_ASSERT(r.upper_bound() == t2);
     } else {
-#ifdef DEBUG
-      RC_ASSERT_THROWS_AS((Range<T>{t1, t2}), krims::ExcTooLarge<T>);
-#endif
+      range_type r{t1, t2};
+      RC_ASSERT(r.empty());
     }
   }
 
@@ -94,7 +93,6 @@ struct RangeTests {
 
 #ifdef DEBUG
     // check that element access throws:
-
     typedef typename range_type::ExcEmptyRange exc_type;
     RC_ASSERT_THROWS_AS(r[0], exc_type);
 #endif


### PR DESCRIPTION
See commit messages.

Most notably the Bugfix in the SetupClangTargets module makes the clang-tidy-krims test in travis fail. We accept this for now and open an issue(#104) for it.